### PR TITLE
Update Linux shared library compile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cp libIOTCAPIs_ALL.dylib /usr/local/lib/
 ```bash
 unzip TUTK_IOTC_Platform_14W42P1.zip
 cd Lib/Linux/x64/
-g++ -fpic -shared -Wl,-whole-archive libAVAPIs.a libIOTCAPIs.a -o libIOTCAPIs_ALL.so
+g++ -fpic -shared -Wl,--whole-archive libAVAPIs.a libIOTCAPIs.a -Wl,--no-whole-archive -o libIOTCAPIs_ALL.so
 cp libIOTCAPIs_ALL.so /usr/local/lib/
 ```
 


### PR DESCRIPTION
## Description

Current Linux instruction for compiling the shared TUTK library are resulting in errors. Seems lit it attempts to load default libraries multiple times. This change allows for successful compilation in Linux environments. 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/kroo/wyzecam/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/kroo/wyzecam/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
