### PR TITLE
expected response code  is always code + 1

### DIFF
--- a/wyzecam/tutk/tutk_ioctl_mux.py
+++ b/wyzecam/tutk/tutk_ioctl_mux.py
@@ -61,9 +61,6 @@ class TutkIOCtrlFuture:
             return self.req.parse_response(self.resp_data)
         if self.errcode:
             raise tutk.TutkError(self.errcode)
-        if self.expected_response_code is None:
-            logger.warning("no response code!")
-            return None
         assert self.queue is not None, "Future created without error nor queue!"
 
         msg = self.queue.get(block=block, timeout=timeout)
@@ -190,9 +187,6 @@ class TutkIOCtrlMux:
         )
         if errcode:
             return TutkIOCtrlFuture(msg, errcode=errcode)
-        if not msg.expected_response_code:
-            logger.warning("no expected response code found")
-            return TutkIOCtrlFuture(msg)
 
         return TutkIOCtrlFuture(msg, self.queues[msg.expected_response_code])
 

--- a/wyzecam/tutk/tutk_protocol.py
+++ b/wyzecam/tutk/tutk_protocol.py
@@ -65,10 +65,8 @@ class TutkWyzeProtocolMessage:
     :var expected_response_code: the code of the message expected to
                                  be the 'response' to this one, from
                                  the camera.
-    :vartype expected_response_code: int
+    :vartype expected_response_code: int is always code + 1
     """
-
-    expected_response_code: typing.Optional[int] = None
 
     def __init__(self, code: int) -> None:
         """Construct a new TutkWyzeProtocolMessage
@@ -78,6 +76,7 @@ class TutkWyzeProtocolMessage:
                    responses from the camera back to the client are always odd.
         """
         self.code = code
+        self.expected_response_code = code + 1
 
     def encode(self) -> bytes:
         """
@@ -109,8 +108,6 @@ class K10000ConnectRequest(TutkWyzeProtocolMessage):
     bytes for the client to sign with the 'enr' of the camera.
     """
 
-    expected_response_code = 10001
-
     def __init__(self):
         """Construct a new K10000ConnectRequest"""
         super().__init__(10000)
@@ -129,8 +126,6 @@ class K10002ConnectAuth(TutkWyzeProtocolMessage):
     The expected response to this command is `10003`, in which the camera provides a json object
     with the result of the authentication exchange (and if successful, a bunch of device information).
     """
-
-    expected_response_code = 10003
 
     def __init__(
         self,
@@ -186,8 +181,6 @@ class K10008ConnectUserAuth(TutkWyzeProtocolMessage):
     with the result of the authentication exchange (and if successful, a bunch of device information).
 
     """
-
-    expected_response_code = 10009
 
     def __init__(
         self,
@@ -247,8 +240,6 @@ class K10010ControlChannel(TutkWyzeProtocolMessage):
     Not terribly well understood.
     """
 
-    expected_response_code = 10011
-
     def __init__(self, k: int = 1, v: int = 2):
         super().__init__(10010)
         assert k < 256, "control channel key must be < 256"
@@ -266,8 +257,6 @@ class K10020CheckCameraInfo(TutkWyzeProtocolMessage):
 
     Not terribly well understood.
     """
-
-    expected_response_code = 10021
 
     def __init__(self):
         super().__init__(10020)
@@ -288,8 +277,6 @@ class K10056SetResolvingBit(TutkWyzeProtocolMessage):
 
     This is sent automatically after the authentication handshake completes successfully.
     """
-
-    expected_response_code = 10057
 
     def __init__(
         self, frame_size=tutk.FRAME_SIZE_1080P, bitrate=tutk.BITRATE_HD
@@ -333,8 +320,6 @@ class K10620CheckNight(TutkWyzeProtocolMessage):
     Not terribly well understood.
     """
 
-    expected_response_code = 10621
-
     def __init__(self):
         super().__init__(10620)
 
@@ -345,8 +330,6 @@ class K10640GetSpotlightStatus(TutkWyzeProtocolMessage):
 
     Not terribly well understood.
     """
-
-    expected_response_code = 10641
 
     def __init__(self):
         super().__init__(10640)


### PR DESCRIPTION
As per the protocol, expected response code  is always code + 1

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/kroo/wyzecam/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/kroo/wyzecam/blob/master/CONTRIBUTING.md) guide.
- [ x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
