### PR TITLE
Update Wyze and iOS version

### DIFF
--- a/wyzecam/api.py
+++ b/wyzecam/api.py
@@ -11,8 +11,8 @@ SV_VALUE = "e1fe392906d54888a9b99b88de4162d7"
 SC_VALUE = "9f275790cab94a72bd206c8876429f3c"
 WYZE_APP_API_KEY = "WMXHYf79Nr5gIlt3r0r7p9Tcw5bvs6BB4U8O8nGJ"
 
-SCALE_USER_AGENT = "Wyze/2.19.24 (iPhone; iOS 14.4.2; Scale/3.00)"
-WYZE_APP_VERSION_NUM = "2.19.24"
+SCALE_USER_AGENT = "Wyze/2.23.23 (iPhone; iOS 14.7.1; Scale/3.00)"
+WYZE_APP_VERSION_NUM = "2.23.23"
 
 
 def login(
@@ -156,7 +156,7 @@ def _get_payload(access_token, phone_id):
     return payload
 
 
-def get_headers(phone_id, user_agent="wyze_ios_2.19.24"):
+def get_headers(phone_id, user_agent="wyze_ios_2.23.23"):
     return {
         "X-API-Key": WYZE_APP_API_KEY,
         "Phone-Id": phone_id,


### PR DESCRIPTION
## Description

Updated Wyze app to **2.23.23** and iOS to **14.7.1**.

API key and SC values remain unchanged from existing values.

Somewhat related:
Current SV value for `user/get_user_info` remains unchanged, however, I noticed that we're reusing the same SV value for `/v2/home_page/get_object_list` which uses an SV value of `9d74946e652647e9b6c9d59326aef104` in the app. Not sure it matters, but thought it might be worth noting.


## Related Issue

None, but had some intermittent "400" errors when logging in. 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/kroo/wyzecam/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/kroo/wyzecam/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
